### PR TITLE
NOTICK: Update the internal publish plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,8 +19,7 @@ pomDeveloperEmail=dev@corda.net
 # Manifest
 docsUrl=https://docs.r3.com
 
-internalPublishVersion = 0.1.1626799016907-beta
-
+internalPublishVersion = 1.0.0
 artifactoryContextUrl=https://software.r3.com/artifactory
 
 corda_release_group=net.corda


### PR DESCRIPTION
start using released versions (first one is 1.0.0)